### PR TITLE
170609716 Fix refresh token flow

### DIFF
--- a/apiproxy/policies/Extract-Refresh-Params.xml
+++ b/apiproxy/policies/Extract-Refresh-Params.xml
@@ -14,6 +14,9 @@
         <Variable name="client_id" type="string">
             <JSONPath>$.client_id</JSONPath>
         </Variable>
+        <Variable name="apikey" type="string">
+            <JSONPath>$.client_id</JSONPath>
+        </Variable>
         <Variable name="client_secret" type="string">
             <JSONPath>$.client_secret</JSONPath>
         </Variable>


### PR DESCRIPTION
Set client_id in 'apikey' variable because 'Set JWT Variables' policy uses it to populate apiProductList.